### PR TITLE
feature: Add sslMode as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ accountDB:
   database: codacy
   username: username
   password: password
+  sslMode: require
 analysisDB:
   host: localhost
   port: 5432
   database: codacy
   username: username
   password: password
+  sslMode: require
 # You may need to lower the batch size from the default value
 # if you experience timeouts when running the script:
 # batchSize: 10000000

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type DatabaseConfiguration struct {
 	Database string
 	Username string
 	Password string
+	SslMode  string
 }
 
 func LoadConfiguration(configFile string) (*Configuration, error) {

--- a/store/db.go
+++ b/store/db.go
@@ -9,7 +9,7 @@ import (
 )
 
 func dbConnectionString(dbConfig config.DatabaseConfiguration) string {
-	return fmt.Sprintf("user=%s password=%s DB.name=%s port=%d host=%s", dbConfig.Username, dbConfig.Password, dbConfig.Database, dbConfig.Port, dbConfig.Host)
+	return fmt.Sprintf("user=%s password=%s DB.name=%s port=%d host=%s sslmode=%s", dbConfig.Username, dbConfig.Password, dbConfig.Database, dbConfig.Port, dbConfig.Host, dbConfig.SslMode)
 }
 
 func connectToDB(dbConfig config.DatabaseConfiguration) (*sql.DB, error) {


### PR DESCRIPTION
It as the same default as it has before, but allows now to be turned off with:
sslMode: disable

This is needed to be 'disable' to test it locally if you don't have sslMode enabled